### PR TITLE
feat support iterate operation

### DIFF
--- a/demo/add.html
+++ b/demo/add.html
@@ -13,11 +13,13 @@
     <script type="text/babel">
       const App = Qox.setup(props => {
         const data = Qox.reactive({ count: 0 })
+        console.log('data: ', data);
         return () => (
           <div>
-            <div>data.count的值:{data.count}</div>
-            <div>data上的所有key:{Object.keys(data).join(',')}</div>
-            <button onClick={() => delete data.count}>删除属性</button>
+            <div>
+              data上的所有key值:{Object.keys(data).join(',')}
+            </div>
+            <button onClick={() => data.newCount = 1}>添加新属性newCount</button>
           </div>
         )
       })

--- a/demo/forEach.html
+++ b/demo/forEach.html
@@ -12,17 +12,24 @@
     <div id="root"></div>
     <script type="text/babel">
       const App = Qox.setup(props => {
-        const data = Qox.reactive({ count: 0 })
-        return () => (
-          <div>
-            <div>data.count的值:{data.count}</div>
-            <div>data上的所有key:{Object.keys(data).join(',')}</div>
-            <button onClick={() => delete data.count}>删除属性</button>
-          </div>
-        )
+        const data = Qox.reactive([1, 2])
+
+        return () => {
+          const values = []
+          data.forEach(value => values.push(value))
+          return (
+            <div>
+              <div>data2值:{values.toString()}</div>
+              <button onClick={() => (delete data[1])}>删除data[1]</button>
+            </div>
+          )
+        }
       })
 
-      ReactDOM.render(<App msg='hello world' />, document.getElementById('root'))
+      ReactDOM.render(
+        <App msg="hello world" />,
+        document.getElementById("root"),
+      )
     </script>
   </body>
 </html>


### PR DESCRIPTION
本次的改动点主要有几个

1. 新增对于数组循环操作的响应式支持，如数组如果用forEach读取，其实会在length这个key上收集依赖，如果新增或者删除值的话，也应该触发循环时候收集的依赖。具体看forEach.html

2. 新增对于对象获取keys的响应式支持，如果用Object.keys或者Reflect.ownKeys之类的操作读取对象的所有key，则在新增或者删除key时也应该触发更新。具体看add.html

3. 改动了获取effect的方法：
```diff
export function setup(component) {
  let vdom = null
  return React.memo(props => {
    if (!vdom) vdom = component(props)
    const update = useForceUpdate()
    trackStack.push(() => update())
-    return vdom(props)
+    let res = vdom(props)
+    trackStack.pop()
+    return res
  })
}
```
```diff
- function track(target, key) {
  - const effect = trackStack.pop()
+ function track(target, key, type?) {
  + const effect = trackStack[trackStack.length - 1]
```


读取方式不能直接用pop，因为在数组读取的时候很可能多次读取，比如forEach时先读取length，再读取具体的值，如果第一次读取就pop掉了，后续就收集不到依赖了。 解决方法是在执行完组件的函数后出栈。



