### PR TITLE
feat support typescript

### DIFF
--- a/demo/add.html
+++ b/demo/add.html
@@ -13,7 +13,6 @@
     <script type="text/babel">
       const App = Qox.setup(props => {
         const data = Qox.reactive({ count: 0 })
-        console.log('data: ', data);
         return () => (
           <div>
             <div>

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.1-pre-alpha",
   "description": "Fast 1kB state management that path-updating.",
   "main": "./dist/qox.js",
+  "types": "./types/index.d.ts",
   "scripts": {
     "test": "jest",
     "start": "rollup -c --watch",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,8 +5,9 @@
     "removeComments": true,
     "lib": ["es5", "es6", "dom"],
     "target": "es5",
-    "jsx": "react"
+    "jsx": "react",
+    "allowSyntheticDefaultImports": true
   },
-  "include": ["packages/**/*"],
+  "include": ["src/**/*"],
   "exclude": ["node_modules"]
 }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,0 +1,22 @@
+export declare function setup<Props extends object>(
+  component: (props: React.PropsWithChildren<Props>) => () => React.ReactNode,
+): React.NamedExoticComponent<
+  Props & {
+    // https://stackoverflow.com/questions/58874899/pass-children-prop-to-react-memo-component?r=SearchResults
+    children?: React.ReactNode
+  }
+>
+export declare function ref(
+  value: any,
+): {
+  value: any
+  isRef: boolean
+}
+export declare function watch(src: any, cb?: any): void
+export declare function computed(
+  getter: Function,
+): {
+  value: any
+}
+export declare function isRef(target: any): boolean
+export declare function reactive<T extends object>(target: T): T


### PR DESCRIPTION
对setup和reactive进行了ts的支持

setup支持通过泛型实现和React.FC同样的效果  

以下类型测试可以通过
```js
import React from "react"
import { setup, reactive } from "qox"

const Test: React.FC = () => (
  <div>
    <ul>
      <li>Webpack</li>
      <li>Node</li>
      <li>Ts</li>
    </ul>
  </div>
)
type Props = { a: number }

const App = setup<Props>(props => {
  const data = reactive({ count: 0 })
  return () => (
    <Test>
      {props.children}
      {data.count}
    </Test>
  )
})

// 也可以是
const App = setup((props: Props)=> {
  const data = reactive({ count: 0 })
  return () => (
    <Test>
      {props.children}
      {data.count}
    </Test>
  )
})
const Comp = <App a={2}>children</App>
export default Comp
```